### PR TITLE
Update bedrock.ts

### DIFF
--- a/src/config/modelProviders/bedrock.ts
+++ b/src/config/modelProviders/bedrock.ts
@@ -32,7 +32,7 @@ const Bedrock: ModelProviderCard = {
       displayName: 'Claude 3.5 Sonnet',
       enabled: true,
       functionCall: true,
-      id: 'us.anthropic.claude-3-5-sonnet-20241022-v2:0',
+      id: 'us-east-1:706092902407:inference-profile/us.anthropic.claude-3-5-sonnet-20241022-v2:0',
       pricing: {
         input: 3,
         output: 15,

--- a/src/config/modelProviders/bedrock.ts
+++ b/src/config/modelProviders/bedrock.ts
@@ -32,7 +32,7 @@ const Bedrock: ModelProviderCard = {
       displayName: 'Claude 3.5 Sonnet',
       enabled: true,
       functionCall: true,
-      id: 'us-east-1:706092902407:inference-profile/us.anthropic.claude-3-5-sonnet-20241022-v2:0',
+      id: 'us.anthropic.claude-3-5-sonnet-20241022-v2:0',
       pricing: {
         input: 3,
         output: 15,

--- a/src/config/modelProviders/bedrock.ts
+++ b/src/config/modelProviders/bedrock.ts
@@ -32,7 +32,7 @@ const Bedrock: ModelProviderCard = {
       displayName: 'Claude 3.5 Sonnet',
       enabled: true,
       functionCall: true,
-      id: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+      id: 'us.anthropic.claude-3-5-sonnet-20241022-v2:0',
       pricing: {
         input: 3,
         output: 15,

--- a/src/config/modelProviders/bedrock.ts
+++ b/src/config/modelProviders/bedrock.ts
@@ -32,6 +32,20 @@ const Bedrock: ModelProviderCard = {
       displayName: 'Claude 3.5 Sonnet',
       enabled: true,
       functionCall: true,
+      id: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+      pricing: {
+        input: 3,
+        output: 15,
+      },
+      tokens: 200_000,
+      vision: true,
+    },
+    {
+      description:
+        'Claude 3.5 Sonnet 提升了行业标准，性能超过竞争对手模型和 Claude 3 Opus，在广泛的评估中表现出色，同时具有我们中等层级模型的速度和成本。',
+      displayName: 'Claude 3.5 Sonnet v2 (Inference profile)',
+      enabled: true,
+      functionCall: true,
       id: 'us.anthropic.claude-3-5-sonnet-20241022-v2:0',
       pricing: {
         input: 3,


### PR DESCRIPTION
Add Claude 3.5 Sonnet v2 inference profile id for access using us-east1 via us-east2.

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

New entrophic sonnet 3.5 v2 model access only allowed to us-east2 region now.
They provide inference id for user having access rule only to us-east1 region.
Lobechat don't have this kind of model access. 
So I just add inference profile to bedrock list.

#### 📝 补充信息 | Additional Information

Refer other solution librechat simular with lobechat.
https://github.com/danny-avila/LibreChat/discussions/4571#discussioncomment-11114851

AWS account should have Bedrock resource below with bedrock:InvokeModelWithResponseStream action.
arn:aws:bedrock:us-east-1:[aws account id]:inference-profile/*
